### PR TITLE
Add carbonyl compound groups

### DIFF
--- a/src/groups.rs
+++ b/src/groups.rs
@@ -4,15 +4,18 @@
 
 use crate::chain;
 use crate::chain::{endpoint_head_chains, longest_chain};
+use crate::compound;
 use crate::groups::InvalidGraphError::{Other, UnrecognizedGroup};
-use crate::molecule::Group::{AcidHalide, Aldehyde, Alkene, Alkyne, Bromo, Carbonyl, Carboxyl, Chloro, Fluoro, Hydrogen, Hydroxyl, Iodo, Nitrile};
+use crate::molecule::Group::{
+    AcidHalide, Aldehyde, Alkene, Alkyne, Bromo, Carbonyl, Carboxyl, Chloro, Fluoro, Hydrogen,
+    Hydroxyl, Iodo, Nitrile,
+};
+use crate::molecule::Halogen::{Bromine, Chlorine, Fluorine, Iodine};
 use crate::molecule::{Atom, BondOrder, Branch, Element, Group, GroupNode, Substituent};
 use crate::pointer::Pointer;
 use crate::spatial::{FromVec2, GridState};
 use ruscii::spatial::{Direction, Vec2};
 use thiserror::Error;
-use crate::molecule::Halogen::{Bromine, Chlorine, Fluorine, Iodine};
-use crate::compound;
 
 /// Generates a [`Branch`] from the given `chain` containing all functional groups attached
 /// to it.
@@ -143,6 +146,8 @@ fn group_patterns(mut groups: Vec<Group>) -> Vec<Substituent> {
     out
 }
 
+/// Takes the given `groups`, matches them against the cases given and returns the resultant
+/// groups to `out`.
 #[macro_export]
 macro_rules! compound {
     ($groups:expr, $out:expr, $([$first:expr, $second:expr => $comp:expr]),*) => {
@@ -368,7 +373,7 @@ mod tests {
 
     #[test]
     fn group_patterns_retains_groups() {
-        let groups = vec![Carbonyl, Bromo, Ether];
+        let groups = vec![Carbonyl, Ether];
         let expected = groups
             .iter()
             .map(|group| Substituent::Group(group.to_owned()))

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -131,7 +131,6 @@ fn group_patterns(mut groups: Vec<Group>) -> Vec<Substituent> {
             [Carbonyl, Bromo => AcidHalide(Bromine)],
             [Carbonyl, Iodo => AcidHalide(Iodine)],
             [Carbonyl, Hydrogen => Aldehyde]
-
         );
         groups.retain(|it| it != &Hydrogen);
         break;

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -311,7 +311,7 @@ mod tests {
     use crate::graph_with;
     use crate::molecule::BondOrder::{Double, Single};
     use crate::molecule::Element::{Br, Cl, C, F, H, I, O};
-    use crate::molecule::Group::{Bromo, Ether};
+    use crate::molecule::Group::Ether;
     use crate::spatial::EnumAll;
     use crate::test_utils::GW::{A, B};
 

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -126,11 +126,11 @@ fn group_patterns(mut groups: Vec<Group>) -> Vec<Substituent> {
     loop {
         compound!(groups, out,
             [Carbonyl, Hydroxyl => Carboxyl],
-            [Carbonyl, Hydrogen => Aldehyde],
             [Carbonyl, Fluoro => AcidHalide(Fluorine)],
             [Carbonyl, Chloro => AcidHalide(Chlorine)],
             [Carbonyl, Bromo => AcidHalide(Bromine)],
-            [Carbonyl, Iodo => AcidHalide(Iodine)]
+            [Carbonyl, Iodo => AcidHalide(Iodine)],
+            [Carbonyl, Hydrogen => Aldehyde]
 
         );
         groups.retain(|it| it != &Hydrogen);

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -5,9 +5,7 @@
 use crate::chain;
 use crate::chain::{endpoint_head_chains, longest_chain};
 use crate::groups::InvalidGraphError::{Other, UnrecognizedGroup};
-use crate::molecule::Group::{
-    Alkene, Alkyne, Bromo, Carbonyl, Carboxyl, Chloro, Fluoro, Hydroxyl, Iodo, Nitrile,
-};
+use crate::molecule::Group::{Aldehyde, Alkene, Alkyne, Bromo, Carbonyl, Carboxyl, Chloro, Fluoro, Hydrogen, Hydroxyl, Iodo, Nitrile};
 use crate::molecule::{Atom, BondOrder, Branch, Element, Group, GroupNode, Substituent};
 use crate::pointer::Pointer;
 use crate::spatial::{FromVec2, GridState};
@@ -100,6 +98,7 @@ fn convert_nodes(group_nodes: Vec<GroupNode>) -> Fallible<Vec<Substituent>> {
 fn identify_single_bond_group(node: GroupNode) -> Fallible<Group> {
     let string = node.to_string();
     let out = match string.as_str() {
+        "1H" => Hydrogen,
         "1B" => Bromo,
         "1L" => Chloro,
         "1F" => Fluoro,
@@ -125,6 +124,12 @@ fn group_patterns(mut groups: Vec<Group>) -> Vec<Substituent> {
             out.push(Substituent::Group(Carboxyl));
             continue;
         }
+        if groups.contains(&Carbonyl) && groups.contains(&Hydrogen) {
+            groups.retain(|it| it != &Carbonyl && it != &Hydrogen);
+            out.push(Substituent::Group(Aldehyde));
+            continue;
+        }
+        groups.retain(|it| it != &Hydrogen);
         break;
     }
 

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -13,6 +13,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use crate::spatial::EnumAll;
 
 /// Represents a type of functional group on a molecule.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -33,6 +34,7 @@ pub enum Group {
     Carbonyl,
     /* Compound groups */
     Aldehyde,
+    AcidHalide(Halogen),
     Carboxyl,
     /* Chain groups */
     Ester,
@@ -56,8 +58,9 @@ impl Group {
             Group::Hydroxyl => 3,
             Group::Carbonyl => 4,
             Group::Aldehyde => 5,
-            Group::Carboxyl => 8,
-            Group::Ester => 7,
+            Group::Carboxyl => 9,
+            Group::AcidHalide(_) => 7,
+            Group::Ester => 8,
             Group::Ether => return None,
             Group::Nitrile => 6,
         };
@@ -85,6 +88,7 @@ impl Display for Group {
             Group::Carbonyl => "oxo",
             Group::Aldehyde => "formyl",
             Group::Carboxyl => "carboxy",
+            Group::AcidHalide(it) => return write!(f, "{}", it.associated_group()),
             Group::Ester => "ester",
             Group::Ether => "ether",
             Group::Nitrile => "cyano",
@@ -127,6 +131,43 @@ impl FromStr for Group {
             _ => return Err(()),
         };
         Ok(out)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Halogen {
+    Fluorine,
+    Chlorine,
+    Bromine,
+    Iodine,
+}
+
+impl Halogen {
+    pub fn associated_group(&self) -> Group{
+        match self {
+            Halogen::Fluorine => Group::Fluoro,
+            Halogen::Chlorine => Group::Chloro,
+            Halogen::Bromine => Group::Bromo,
+            Halogen::Iodine => Group::Iodo,
+        }
+    }
+}
+
+impl Display for Halogen {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let str = match self {
+            Halogen::Fluorine => "fluoride",
+            Halogen::Chlorine => "chloride",
+            Halogen::Bromine => "bromide",
+            Halogen::Iodine => "iodide",
+        };
+        write!(f, "{str}")
+    }
+}
+
+impl EnumAll for Halogen {
+    fn all() -> Vec<Self> where Self: Sized {
+        vec![Halogen::Fluorine, Halogen::Chlorine, Halogen::Bromine, Halogen::Iodine]
     }
 }
 

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -52,17 +52,20 @@ impl Group {
     /// the main group_ (i.e., always a prefix).
     pub const fn priority(self) -> Option<i32> {
         let priority = match self {
-            Group::Hydrogen => return None,
-            Group::Alkane | Group::Alkene | Group::Alkyne => 0,
-            Group::Bromo | Group::Chloro | Group::Fluoro | Group::Iodo => return None,
-            Group::Hydroxyl => 3,
-            Group::Carbonyl => 4,
-            Group::Aldehyde => 5,
-            Group::Carboxyl => 9,
-            Group::AcidHalide(_) => 7,
-            Group::Ester => 8,
-            Group::Ether => return None,
+            Group::Carboxyl => 12,
+            Group::Ester => 11,
+            Group::AcidHalide(halogen) => match halogen {
+                Halogen::Fluorine => 10,
+                Halogen::Chlorine => 9,
+                Halogen::Bromine => 8,
+                Halogen::Iodine => 7,
+            }
             Group::Nitrile => 6,
+            Group::Aldehyde => 5,
+            Group::Carbonyl => 4,
+            Group::Hydroxyl => 3,
+            Group::Alkane | Group::Alkene | Group::Alkyne => 0,
+            Group::Hydrogen | Group::Bromo | Group::Chloro | Group::Fluoro | Group::Iodo | Group::Ether => return None,
         };
         Some(priority)
     }

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -59,13 +59,18 @@ impl Group {
                 Halogen::Chlorine => 9,
                 Halogen::Bromine => 8,
                 Halogen::Iodine => 7,
-            }
+            },
             Group::Nitrile => 6,
             Group::Aldehyde => 5,
             Group::Carbonyl => 4,
             Group::Hydroxyl => 3,
             Group::Alkane | Group::Alkene | Group::Alkyne => 0,
-            Group::Hydrogen | Group::Bromo | Group::Chloro | Group::Fluoro | Group::Iodo | Group::Ether => return None,
+            Group::Hydrogen
+            | Group::Bromo
+            | Group::Chloro
+            | Group::Fluoro
+            | Group::Iodo
+            | Group::Ether => return None,
         };
         Some(priority)
     }

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -6,6 +6,7 @@ use crate::molecule::BondOrder::{Double, Single, Triple};
 use crate::molecule::BondOrientation::{Horiz, Vert};
 use crate::molecule::Element::{C, H, N, O};
 use crate::naming::process_name;
+use crate::spatial::EnumAll;
 use ruscii::spatial::{Direction, Vec2};
 use ruscii::terminal::Color;
 use ruscii::terminal::Color::{Blue, Green, LightGrey, Magenta, Red, White, Xterm, Yellow};
@@ -13,7 +14,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use crate::spatial::EnumAll;
 
 /// Represents a type of functional group on a molecule.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -143,7 +143,7 @@ pub enum Halogen {
 }
 
 impl Halogen {
-    pub fn associated_group(&self) -> Group{
+    pub fn associated_group(&self) -> Group {
         match self {
             Halogen::Fluorine => Group::Fluoro,
             Halogen::Chlorine => Group::Chloro,
@@ -166,8 +166,16 @@ impl Display for Halogen {
 }
 
 impl EnumAll for Halogen {
-    fn all() -> Vec<Self> where Self: Sized {
-        vec![Halogen::Fluorine, Halogen::Chlorine, Halogen::Bromine, Halogen::Iodine]
+    fn all() -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        vec![
+            Halogen::Fluorine,
+            Halogen::Chlorine,
+            Halogen::Bromine,
+            Halogen::Iodine,
+        ]
     }
 }
 

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -88,7 +88,7 @@ impl Display for Group {
             Group::Carbonyl => "oxo",
             Group::Aldehyde => "formyl",
             Group::Carboxyl => "carboxy",
-            Group::AcidHalide(it) => return write!(f, "{}", it.associated_group()),
+            Group::AcidHalide(it) => return write!(f, "{}carbonyl", it.associated_group()),
             Group::Ester => "ester",
             Group::Ether => "ether",
             Group::Nitrile => "cyano",

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -17,7 +17,9 @@ use std::str::FromStr;
 /// Represents a type of functional group on a molecule.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Group {
-    /* Chain groups */
+    /* Not a group, but useful */
+    Hydrogen,
+    /* Multiple bond groups */
     Alkane,
     Alkene,
     Alkyne,
@@ -29,8 +31,10 @@ pub enum Group {
     /* General groups */
     Hydroxyl,
     Carbonyl,
+    /* Compound groups */
+    Aldehyde,
     Carboxyl,
-    /* Phenyl later */
+    /* Chain groups */
     Ester,
     Ether,
     /* Nitrogen groups */
@@ -46,14 +50,16 @@ impl Group {
     /// the main group_ (i.e., always a prefix).
     pub const fn priority(self) -> Option<i32> {
         let priority = match self {
+            Group::Hydrogen => return None,
             Group::Alkane | Group::Alkene | Group::Alkyne => 0,
             Group::Bromo | Group::Chloro | Group::Fluoro | Group::Iodo => return None,
             Group::Hydroxyl => 3,
             Group::Carbonyl => 4,
-            Group::Carboxyl => 7,
-            Group::Ester => 6,
+            Group::Aldehyde => 5,
+            Group::Carboxyl => 8,
+            Group::Ester => 7,
             Group::Ether => return None,
-            Group::Nitrile => 5,
+            Group::Nitrile => 6,
         };
         Some(priority)
     }
@@ -67,6 +73,7 @@ impl Display for Group {
     /// Displays the ionic prefix for the current [`Group`].
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let str = match *self {
+            Group::Hydrogen => "",
             Group::Alkane => "an",
             Group::Alkene => "en",
             Group::Alkyne => "yn",
@@ -76,6 +83,7 @@ impl Display for Group {
             Group::Iodo => "iodo",
             Group::Hydroxyl => "hydroxy",
             Group::Carbonyl => "oxo",
+            Group::Aldehyde => "formyl",
             Group::Carboxyl => "carboxy",
             Group::Ester => "ester",
             Group::Ether => "ether",
@@ -102,6 +110,7 @@ impl FromStr for Group {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let out = match s {
+            "hydrogen" => Group::Hydrogen,
             "alkane" => Group::Alkane,
             "alkene" => Group::Alkene,
             "alkyne" => Group::Alkyne,

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -99,7 +99,9 @@ fn suffix(fragment: SubFragment) -> Result<String, NamingError> {
             Group::Hydroxyl => "ol",
             Group::Nitrile if fragment.locants.len() == 2 => return Ok("edinitrile".to_string()),
             Group::Nitrile => return Ok("onitrile".to_string()),
-            Group::AcidHalide(it) if fragment.locants.len() == 2 => return Ok(format!("edioyl di{it}")),
+            Group::AcidHalide(it) if fragment.locants.len() == 2 => {
+                return Ok(format!("edioyl di{it}"))
+            }
             Group::AcidHalide(it) => return Ok(format!("oyl {it}")),
             _ => return Ok("e".to_string()),
         };

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -93,13 +93,12 @@ fn suffix(fragment: SubFragment) -> Result<String, NamingError> {
         let suffix = match group {
             Group::Carboxyl if fragment.locants.len() == 2 => return Ok("edioic acid".to_string()),
             Group::Carboxyl => return Ok("oic acid".to_string()),
-            Group::Carbonyl if fragment.locants == vec![0, fragment.locants.len() as i32 - 1] => {
-                return Ok("edial".to_string())
-            }
+            Group::Aldehyde if fragment.locants.len() == 2 => return Ok("edial".to_string()),
             Group::Aldehyde => return Ok("al".to_string()),
             Group::Carbonyl => "one",
             Group::Hydroxyl => "ol",
-            Group::Nitrile => "onitrile",
+            Group::Nitrile if fragment.locants.len() == 2 => return Ok("edinitrile".to_string()),
+            Group::Nitrile => return Ok("onitrile".to_string()),
             Group::AcidHalide(it) if fragment.locants.len() == 2 => return Ok(format!("edioyl di{it}")),
             Group::AcidHalide(it) => return Ok(format!("oyl {it}")),
             _ => return Ok("e".to_string()),

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -96,7 +96,7 @@ fn suffix(fragment: SubFragment) -> Result<String, NamingError> {
             Group::Carbonyl if fragment.locants == vec![0, fragment.locants.len() as i32 - 1] => {
                 return Ok("edial".to_string())
             }
-            Group::Carbonyl if fragment.locants == vec![0] => return Ok("al".to_string()),
+            Group::Aldehyde => return Ok("al".to_string()),
             Group::Carbonyl => "one",
             Group::Hydroxyl => "ol",
             Group::Nitrile => "onitrile",

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -100,6 +100,7 @@ fn suffix(fragment: SubFragment) -> Result<String, NamingError> {
             Group::Carbonyl => "one",
             Group::Hydroxyl => "ol",
             Group::Nitrile => "onitrile",
+            Group::AcidHalide(it) => return Ok(format!("oyl {it}")),
             _ => return Ok("e".to_string()),
         };
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -100,6 +100,7 @@ fn suffix(fragment: SubFragment) -> Result<String, NamingError> {
             Group::Carbonyl => "one",
             Group::Hydroxyl => "ol",
             Group::Nitrile => "onitrile",
+            Group::AcidHalide(it) if fragment.locants.len() == 2 => return Ok(format!("edioyl di{it}")),
             Group::AcidHalide(it) => return Ok(format!("oyl {it}")),
             _ => return Ok("e".to_string()),
         };


### PR DESCRIPTION
An aldehyde should be recognized as a carbonyl + hydrogen compound instead of an ending group so that acid halides can be defined as carbonyl + halide groups.