### PR TITLE
Fix parent chain rule

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -12,15 +12,15 @@ use crate::pointer::Pointer;
 use crate::spatial::GridState;
 use ruscii::spatial::Vec2;
 
-/// Gets the primary chain of the given [`Vec`] of chains according to
+/// Gets the parent chain of the given [`Vec`] of chains according to
 /// [IUPAC rules](https://en.wikipedia.org/wiki/IUPAC_nomenclature_of_organic_chemistry) on
-/// Wikipedia, accessed 26 Mar 2023. The primary chain is, in order of precedence, that which:
+/// Wikipedia, accessed 26 Mar 2023. The parent chain is, in order of precedence, that which:
 /// 1. has the greatest number of occurrences of the primary functional group.
 /// 2. has the greatest number of multiple bonds.
 /// 3. is the longest.
 /// 3. has the greatest number of occurrences of prefix substituents.
 /// 4. has the greatest number of single bonds.
-pub fn primary_chain(
+pub fn parent_chain(
     graph: &GridState,
     chains: Vec<Vec<Atom>>,
     parent: Option<Atom>,

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -50,12 +50,15 @@ pub fn primary_chain(
         .iter()
         .flat_map(|it| it.groups.to_owned())
         .flatten()
-        .filter(|it| matches!(it, Substituent::Group(_)))
-        .map(|it| {
+        .filter_map(|it| {
             if let Substituent::Group(group) = it {
-                group
+                if group.seniority().is_some() {
+                    Some(group)
+                } else {
+                    None
+                }
             } else {
-                panic!("call to filter() failed")
+                None
             }
         })
         .max_by_key(|it| it.seniority());

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -3,7 +3,7 @@
 //! The `groups` module provides functionality for identifying functional groups on a branch.
 
 use crate::chain;
-use crate::chain::{endpoint_head_chains, primary_chain};
+use crate::chain::{endpoint_head_chains, parent_chain};
 use crate::compound;
 use crate::groups::InvalidGraphError::{Other, UnrecognizedGroup};
 use crate::molecule::Group::{
@@ -75,7 +75,7 @@ pub(crate) fn link_groups(
 
 pub(crate) fn debug_branches(graph: &GridState) -> Fallible<Branch> {
     let all_chains = chain::get_all_chains(graph)?;
-    let chain = primary_chain(graph, all_chains, None)?;
+    let chain = parent_chain(graph, all_chains, None)?;
     link_groups(graph, chain, None)
 }
 
@@ -209,7 +209,7 @@ pub(crate) fn branch_node_tree(
 ) -> Fallible<Vec<Atom>> {
     let atom = Pointer::new(graph, pos).traverse_bond(direction)?;
     let chains = endpoint_head_chains(atom, graph, Some(pos))?;
-    primary_chain(
+    parent_chain(
         graph,
         chains,
         Some(

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -3,7 +3,7 @@
 //! The `naming` module contains functions that makes final validations and finds the name of
 //! an organic molecule as a [`Branch`].
 
-use crate::chain::primary_chain;
+use crate::chain::parent_chain;
 use crate::groups::Fallible;
 use crate::groups::InvalidGraphError::Other;
 use crate::molecule::Group::Alkane;
@@ -44,7 +44,7 @@ pub fn name_molecule(graph: &GridState) -> Fallible<String> {
 
     // Preliminary chain
     let all_chains = get_all_chains(graph)?;
-    let chain = primary_chain(graph, all_chains, None)?;
+    let chain = parent_chain(graph, all_chains, None)?;
 
     // Group-linked branch
     let mut branch = link_groups(graph, chain, None)?;


### PR DESCRIPTION
A bug was found where groups that could not be primary groups (groups that are never suffixes, e.g., chloro groups) were being considered primary for the purposes of rule 1 of the parent chain identification ruleset.

This pull request also renames 'primary chain' to 'parent chain' for more accurate terminology.