### PR TITLE
Add parent chain highlighting

### DIFF
--- a/src/groups.rs
+++ b/src/groups.rs
@@ -47,7 +47,9 @@ pub(crate) fn link_groups(
         let mut chain_nodes = directions
             .1
             .into_iter()
-            .map(|dir| branch_node_tree(graph, accumulator.chain[index].pos, dir).unwrap())
+            .map(|dir| branch_node_tree(graph, accumulator.chain[index].pos, dir))
+            .collect::<Fallible<Vec<Vec<Atom>>>>()?
+            .into_iter()
             .map(|chain| {
                 link_groups(
                     graph,
@@ -57,8 +59,9 @@ pub(crate) fn link_groups(
                         pos: accumulator.chain[index].pos,
                     }),
                 )
-                .unwrap()
             })
+            .collect::<Fallible<Vec<Branch>>>()?
+            .into_iter()
             .map(Substituent::Branch)
             .collect::<Vec<Substituent>>();
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -2,7 +2,6 @@
 //!
 //! The `gui` module provides functions for drawing various UI elements.
 
-use Color::Red;
 use crate::molecule::Cell;
 use crate::spatial::{GridState, Invert};
 use crate::Mode;
@@ -11,6 +10,7 @@ use ruscii::drawing::{Pencil, RectCharset};
 use ruscii::spatial::Vec2;
 use ruscii::terminal::Color;
 use ruscii::terminal::Color::Cyan;
+use Color::Red;
 
 pub(crate) fn draw_grid_box(pencil: &mut Pencil, graph_size: Vec2, pos: Vec2) {
     pencil.draw_rect(
@@ -51,7 +51,7 @@ pub(crate) fn draw_grid(
     graph: &mut GridState,
     chain_highlighting: &Option<Vec<Vec2>>,
     pos: Vec2,
-    mode: Mode
+    mode: Mode,
 ) {
     pencil.move_origin(pos);
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -2,12 +2,14 @@
 //!
 //! The `gui` module provides functions for drawing various UI elements.
 
+use Color::Red;
 use crate::molecule::Cell;
 use crate::spatial::{GridState, Invert};
 use crate::Mode;
 use crate::Mode::{Insert, Normal};
 use ruscii::drawing::{Pencil, RectCharset};
 use ruscii::spatial::Vec2;
+use ruscii::terminal::Color;
 use ruscii::terminal::Color::Cyan;
 
 pub(crate) fn draw_grid_box(pencil: &mut Pencil, graph_size: Vec2, pos: Vec2) {
@@ -44,11 +46,29 @@ pub(crate) fn draw_logo(pencil: &mut Pencil, graph_size: Vec2, pos: Vec2) {
         .move_origin(-pos);
 }
 
-pub(crate) fn draw_grid(pencil: &mut Pencil, graph: &mut GridState, pos: Vec2, mode: Mode) {
+pub(crate) fn draw_grid(
+    pencil: &mut Pencil,
+    graph: &mut GridState,
+    chain_highlighting: &Option<Vec<Vec2>>,
+    pos: Vec2,
+    mode: Mode
+) {
     pencil.move_origin(pos);
 
     for cell in graph.cells.iter().flatten() {
-        pencil.set_foreground(cell.color()).draw_text(
+        let color = if let Some(it) = chain_highlighting {
+            if cell.pos() == it[0] {
+                Cyan
+            } else if it.contains(&cell.pos()) {
+                Red
+            } else {
+                cell.color()
+            }
+        } else {
+            cell.color()
+        };
+
+        pencil.set_foreground(color).draw_text(
             match &cell {
                 Cell::Atom(it) => it.symbol(),
                 Cell::Bond(it) => it.symbol(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,14 +6,15 @@ use crate::groups::debug_branches;
 use crate::macros::invoke_macro;
 use crate::molecule::BondOrder::{Double, Single, Triple};
 use crate::molecule::Element::{Cl, C, H, I, N, O};
-use crate::molecule::{ComponentType, Element};
+use crate::molecule::{Atom, ComponentType, Element};
 use crate::naming::name_molecule;
-use crate::spatial::GridState;
+use crate::spatial::{FromVec2, GridState};
 use crate::{AppState, Mode};
 use ruscii::app::State;
 use ruscii::keyboard::{Key, KeyEvent};
-use ruscii::spatial::Direction;
+use ruscii::spatial::{Direction, Vec2};
 use Element::{Br, F};
+use crate::pointer::Pointer;
 
 pub(crate) fn input_insert_mode(app_state: &State, state: &mut AppState, graph: &mut GridState) {
     for key_event in app_state.keyboard().last_key_events() {
@@ -40,6 +41,7 @@ pub(crate) fn input_insert_mode(app_state: &State, state: &mut AppState, graph: 
             KeyEvent::Pressed(Key::Num1) => update(state, graph, ComponentType::Order(Single)),
             KeyEvent::Pressed(Key::Num2) => update(state, graph, ComponentType::Order(Double)),
             KeyEvent::Pressed(Key::Num3) => update(state, graph, ComponentType::Order(Triple)),
+            KeyEvent::Pressed(Key::Num0) => state.parent_chain_enabled = !state.parent_chain_enabled,
             KeyEvent::Pressed(Key::Backspace) => update(state, graph, ComponentType::None),
             KeyEvent::Pressed(Key::Right) => graph.move_cursor(Direction::Right),
             KeyEvent::Pressed(Key::Left) => graph.move_cursor(Direction::Left),
@@ -56,6 +58,7 @@ pub(crate) fn input_view_mode(app_state: &State, state: &mut AppState) {
         match key_event {
             KeyEvent::Pressed(Key::Esc) => app_state.stop(),
             KeyEvent::Pressed(Key::F8) => state.mode = Mode::Insert,
+            KeyEvent::Pressed(Key::Num0) => state.parent_chain_enabled = !state.parent_chain_enabled,
             _ => (),
         }
     }
@@ -86,8 +89,35 @@ pub(crate) fn update(state: &mut AppState, graph: &mut GridState, comp: Componen
         invoke_macro(graph, comp, previous);
     }
 
-    (state.name, state.err) = match name_molecule(graph) {
+    let mut chain = None;
+
+    (state.name, state.err) = match name_molecule(graph, &mut chain) {
         Ok(it) => (it, false),
         Err(it) => (it.to_string(), true),
     };
+
+    if let Some(it) = chain {
+        state.parent_chain = Some(get_chain_path(graph, it))
+    }
+}
+
+fn get_chain_path(graph: &GridState, chain: Vec<Atom>) -> Vec<Vec2> {
+    let mut out = vec![];
+
+    for atoms in chain.windows(2) {
+        let direction = Direction::from_points(atoms[0].pos, atoms[1].pos).unwrap();
+        let mut ptr = Pointer::new(graph, atoms[0].pos);
+
+        'inner: loop {
+            out.push(ptr.borrow().unwrap().pos());
+            ptr.move_ptr(direction);
+
+            if ptr.pos == atoms[1].pos {
+                break 'inner;
+            }
+        }
+    }
+    
+    out.push(chain.last().unwrap().pos);
+    out
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,13 +8,13 @@ use crate::molecule::BondOrder::{Double, Single, Triple};
 use crate::molecule::Element::{Cl, C, H, I, N, O};
 use crate::molecule::{Atom, ComponentType, Element};
 use crate::naming::name_molecule;
+use crate::pointer::Pointer;
 use crate::spatial::{FromVec2, GridState};
 use crate::{AppState, Mode};
 use ruscii::app::State;
 use ruscii::keyboard::{Key, KeyEvent};
 use ruscii::spatial::{Direction, Vec2};
 use Element::{Br, F};
-use crate::pointer::Pointer;
 
 pub(crate) fn input_insert_mode(app_state: &State, state: &mut AppState, graph: &mut GridState) {
     for key_event in app_state.keyboard().last_key_events() {
@@ -41,7 +41,9 @@ pub(crate) fn input_insert_mode(app_state: &State, state: &mut AppState, graph: 
             KeyEvent::Pressed(Key::Num1) => update(state, graph, ComponentType::Order(Single)),
             KeyEvent::Pressed(Key::Num2) => update(state, graph, ComponentType::Order(Double)),
             KeyEvent::Pressed(Key::Num3) => update(state, graph, ComponentType::Order(Triple)),
-            KeyEvent::Pressed(Key::Num0) => state.parent_chain_enabled = !state.parent_chain_enabled,
+            KeyEvent::Pressed(Key::Num0) => {
+                state.parent_chain_enabled = !state.parent_chain_enabled
+            }
             KeyEvent::Pressed(Key::Backspace) => update(state, graph, ComponentType::None),
             KeyEvent::Pressed(Key::Right) => graph.move_cursor(Direction::Right),
             KeyEvent::Pressed(Key::Left) => graph.move_cursor(Direction::Left),
@@ -58,7 +60,9 @@ pub(crate) fn input_view_mode(app_state: &State, state: &mut AppState) {
         match key_event {
             KeyEvent::Pressed(Key::Esc) => app_state.stop(),
             KeyEvent::Pressed(Key::F8) => state.mode = Mode::Insert,
-            KeyEvent::Pressed(Key::Num0) => state.parent_chain_enabled = !state.parent_chain_enabled,
+            KeyEvent::Pressed(Key::Num0) => {
+                state.parent_chain_enabled = !state.parent_chain_enabled
+            }
             _ => (),
         }
     }
@@ -117,7 +121,7 @@ fn get_chain_path(graph: &GridState, chain: Vec<Atom>) -> Vec<Vec2> {
             }
         }
     }
-    
+
     out.push(chain.last().unwrap().pos);
     out
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 use crate::gui::draw_grid_box;
 use crate::input::{input_insert_mode, input_view_mode, start_mode};
 use crate::molecule::BondOrder::{Double, Single, Triple};
-use crate::molecule::{Atom, Bond, BondOrientation, Cell, ComponentType, Element};
+use crate::molecule::{Bond, BondOrientation, Cell, ComponentType, Element};
 use crate::spatial::{EnumAll, GridState};
 use crate::Mode::Insert;
 use ruscii::app::{App, State};
@@ -72,9 +72,13 @@ fn main() {
             _ => gui::draw_grid(
                 &mut pencil,
                 &mut graph,
-                if state.parent_chain_enabled { &state.parent_chain } else { &None },
+                if state.parent_chain_enabled {
+                    &state.parent_chain
+                } else {
+                    &None
+                },
                 Vec2::y(2),
-                state.mode
+                state.mode,
             ),
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 use crate::gui::draw_grid_box;
 use crate::input::{input_insert_mode, input_view_mode, start_mode};
 use crate::molecule::BondOrder::{Double, Single, Triple};
-use crate::molecule::{Bond, BondOrientation, Cell, ComponentType, Element};
+use crate::molecule::{Atom, Bond, BondOrientation, Cell, ComponentType, Element};
 use crate::spatial::{EnumAll, GridState};
 use crate::Mode::Insert;
 use ruscii::app::{App, State};
@@ -69,7 +69,13 @@ fn main() {
                 gui::draw_logo(&mut pencil, graph.size, Vec2::y(2));
                 gui::draw_start_message(&mut pencil, Vec2::xy(graph.size.x * 3 + 5, 1));
             }
-            _ => gui::draw_grid(&mut pencil, &mut graph, Vec2::y(2), state.mode),
+            _ => gui::draw_grid(
+                &mut pencil,
+                &mut graph,
+                if state.parent_chain_enabled { &state.parent_chain } else { &None },
+                Vec2::y(2),
+                state.mode
+            ),
         }
 
         draw_grid_box(&mut pencil, graph.size, Vec2::xy(-1, 1));
@@ -268,6 +274,8 @@ struct AppState {
     err: bool,
     debug: String,
     macros_enabled: bool,
+    parent_chain_enabled: bool,
+    parent_chain: Option<Vec<Vec2>>,
 }
 
 #[cfg(test)]

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -22,7 +22,7 @@ use validation::{check_structure, check_valence};
 ///
 /// If the molecule on the given `graph` is discontinuous, cyclic, or contains invalid bonding,
 /// an [`InvalidGraphError`] will be returned.
-pub fn name_molecule(graph: &GridState) -> Fallible<String> {
+pub fn name_molecule(graph: &GridState, parent_chain_out: &mut Option<Vec<Atom>>) -> Fallible<String> {
     let cells = graph
         .find_all(|cell| cell.is_atom())
         .iter()
@@ -39,11 +39,13 @@ pub fn name_molecule(graph: &GridState) -> Fallible<String> {
     // Preliminary chain
     let all_chains = get_all_chains(graph)?;
     let chain = parent_chain(graph, all_chains, None)?;
-
+    
     // Group-linked branch
     let mut branch = link_groups(graph, chain, None)?;
     branch = branch.index_corrected()?;
 
+    *parent_chain_out = Some(branch.chain.clone());
+    
     process_name(branch).map_err(|e| Other(e.to_string()))
 }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -7,7 +7,7 @@ use crate::chain::parent_chain;
 use crate::groups::Fallible;
 use crate::groups::InvalidGraphError::Other;
 use crate::molecule::Group::Alkane;
-use crate::molecule::{Atom, Branch, Cell, Group, Substituent};
+use crate::molecule::{Atom, Branch, Group, Substituent};
 use crate::spatial::GridState;
 use crate::{chain, groups, validation};
 use chain::get_all_chains;
@@ -22,7 +22,10 @@ use validation::{check_structure, check_valence};
 ///
 /// If the molecule on the given `graph` is discontinuous, cyclic, or contains invalid bonding,
 /// an [`InvalidGraphError`] will be returned.
-pub fn name_molecule(graph: &GridState, parent_chain_out: &mut Option<Vec<Atom>>) -> Fallible<String> {
+pub fn name_molecule(
+    graph: &GridState,
+    parent_chain_out: &mut Option<Vec<Atom>>,
+) -> Fallible<String> {
     let cells = graph
         .find_all(|cell| cell.is_atom())
         .iter()
@@ -39,13 +42,13 @@ pub fn name_molecule(graph: &GridState, parent_chain_out: &mut Option<Vec<Atom>>
     // Preliminary chain
     let all_chains = get_all_chains(graph)?;
     let chain = parent_chain(graph, all_chains, None)?;
-    
+
     // Group-linked branch
     let mut branch = link_groups(graph, chain, None)?;
     branch = branch.index_corrected()?;
 
     *parent_chain_out = Some(branch.chain.clone());
-    
+
     process_name(branch).map_err(|e| Other(e.to_string()))
 }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -26,13 +26,7 @@ pub fn name_molecule(graph: &GridState) -> Fallible<String> {
     let cells = graph
         .find_all(|cell| cell.is_atom())
         .iter()
-        .map(|&cell| {
-            if let Cell::Atom(it) = cell {
-                it.to_owned()
-            } else {
-                panic!("is_atom check failed in name_molecule")
-            }
-        })
+        .map(|&cell| cell.unwrap_atom())
         .collect::<Vec<Atom>>();
 
     // Initial checks


### PR DESCRIPTION
It is often useful to see the parent chain in a large molecule for understanding why an organic molecule is named how it is and, more importantly, for debugging.

This adds highlighting in red for the carbon chain and cyan for the first atom in the chain which can be toggled by pressing the 0 key.